### PR TITLE
Use new $PATIENT_ID wildcard parameter

### DIFF
--- a/client/src/flexpa_types.d.ts
+++ b/client/src/flexpa_types.d.ts
@@ -1,6 +1,5 @@
 export interface LinkExchangeResponse {
   accessToken: string;
-  patientId: string;
   expiresIn: number;
 }
 

--- a/client/src/link_success.ts
+++ b/client/src/link_success.ts
@@ -7,7 +7,7 @@ function displaySuccessMessage(app: LinkExchangeResponse) {
             Success, your health plan has been linked!
         </h1>
         <div>
-            The access token and patient ID are now stored in the AppContext.
+            The access token is now stored in the AppContext.
             The application is ready to start making FHIR resource requests.
         </div>
     </div>

--- a/client/src/link_success.ts
+++ b/client/src/link_success.ts
@@ -13,10 +13,6 @@ function displaySuccessMessage(app: LinkExchangeResponse) {
     </div>
     <div>
         <div class='app-context'>
-            <div class='table-heading'>Patient ID</div>
-            <div class='code'>${app?.patientId}</div>
-        </div>
-        <div class='app-context'>
             <div class='table-heading'>Access Token</div>
             <div class='code'>${app?.accessToken}</div>
         </div>

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -44,14 +44,14 @@ function initializePage() {
       }
 
       // Parse the response body
-      const { accessToken, patientId, expiresIn } = await resp.json() as LinkExchangeResponse;
+      const { accessToken, expiresIn } = await resp.json() as LinkExchangeResponse;
       const flexpaLinkDiv = document.getElementById("flexpa-link");
       if (!flexpaLinkDiv) {
         console.error("Could not find the Flexpa Link div");
         return;
       }
 
-      flexpaLinkDiv.innerHTML = displaySuccessMessage({ accessToken, patientId, expiresIn });
+      flexpaLinkDiv.innerHTML = displaySuccessMessage({ accessToken, expiresIn });
 
       const appDiv = document.getElementById("coverage-container");
       if (!appDiv) {
@@ -70,11 +70,11 @@ function initializePage() {
       </div>
       `;
 
-      /*  Using the accessToken and patientId returned from `POST /flexpa-access-token` make a search request
+      /*  Using the accessToken returned from `POST /flexpa-access-token` make a search request
           to the patient's payer FHIR server through `https://api.flexpa.com/fhir`.
-          Include the `patientId` in the query parameter and the `accessToken` within the `authorization`
+          Include the `$PATIENT_ID` wildcard in the query parameter and the `accessToken` within the `authorization`
           HTTP header. */
-      const fhirCoverageResp = await fetch(`${import.meta.env.VITE_FLEXPA_PUBLIC_FHIR_BASE_URL}/Coverage?patient=${patientId}`, {
+      const fhirCoverageResp = await fetch(`${import.meta.env.VITE_FLEXPA_PUBLIC_FHIR_BASE_URL}/Coverage?patient=$PATIENT_ID`, {
         method: "GET",
         headers: {
           authorization: `Bearer ${accessToken}`,
@@ -89,7 +89,7 @@ function initializePage() {
 
       /*  Load the current Patient using a FHIR read request
           see https://www.hl7.org/fhir/patient.html for available fields */
-      const fhirPatientResp = await fetch(`${import.meta.env.VITE_FLEXPA_PUBLIC_FHIR_BASE_URL}/Patient/${patientId}`, {
+      const fhirPatientResp = await fetch(`${import.meta.env.VITE_FLEXPA_PUBLIC_FHIR_BASE_URL}/Patient/$PATIENT_ID`, {
         method: "GET",
         headers: {
           authorization: `Bearer ${accessToken}`,

--- a/server/src/routes/flexpa_api_token.ts
+++ b/server/src/routes/flexpa_api_token.ts
@@ -5,7 +5,6 @@ const router: Router = express.Router();
 
 interface LinkExchangeResponse {
   access_token: string;
-  patient_id: string;
   expires_in: number;
 }
 
@@ -14,7 +13,7 @@ interface FlexpaAccessTokenBody {
 }
 /**
  * POST /flexpa-access-token
- * Exchanges your `publicToken` for an `access_token` and `patient_id`
+ * Exchanges your `publicToken` for an `access_token`
  */
 router.post("/flexpa-access-token", async (req: Request, res: Response) => {
   const { publicToken } = req.body as FlexpaAccessTokenBody;
@@ -27,7 +26,7 @@ router.post("/flexpa-access-token", async (req: Request, res: Response) => {
     return res.status(500).send('Invalid public API base URL');
   }
 
-  // Call Flexpa API's exchange endpoint to exchange your `publicToken` for an `access_token` and a `patient_id`
+  // Call Flexpa API's exchange endpoint to exchange your `publicToken` for an `access_token`
   try {
     const resp = await fetch(`${process.env.FLEXPA_PUBLIC_API_BASE_URL}/link/exchange`, {
       method: "POST",
@@ -39,9 +38,9 @@ router.post("/flexpa-access-token", async (req: Request, res: Response) => {
         secret_key: process.env.FLEXPA_API_SECRET_KEY,
       }),
     });
-    const { access_token: accessToken, patient_id: patientId, expires_in: expiresIn } = await resp.json() as LinkExchangeResponse;
+    const { access_token: accessToken, expires_in: expiresIn } = await resp.json() as LinkExchangeResponse;
 
-    res.send({ accessToken, patientId, expiresIn });
+    res.send({ accessToken, expiresIn });
   }
   catch (err) {
     return res.status(500).send(`Error exchanging token: ${err}`);


### PR DESCRIPTION
### Why
- Patient wildcard parameter is being added to FlexpaAPI. This is a breaking change so quickstart must be updated as well

### What 
- Removed references to `patient_id` which is no longer returned from `link/exchange`
- Updated the resource requests to use `$PATIENT_ID` wildcard parameter instead of `patient_id`