### PR TITLE
feat: Use new Flexpa infrastructure by default

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package*.json
+.idea/
+dist

--- a/client/.env.template
+++ b/client/.env.template
@@ -1,11 +1,7 @@
-
-# This URL is used to connect with Flexpa.
-VITE_FLEXPA_PUBLIC_FHIR_BASE_URL=https://api.flexpa.com/fhir
-
 # This is the URL to this application's backend server
 VITE_SERVER_URL=http://localhost:9000
 
 # Add your Flexpa publishable key here
-# You will be given two sets of publishable and secret keys, one for test mode and one for production. Be sure to enter the correct keys for your use case. 
+# You will be given two sets of publishable and secret keys, one for test mode and one for production. Be sure to enter the correct keys for your use case.
 # If test keys are used, a badge will appear on the Flexpa Link dialog indicating that the application is in test mode.
 VITE_FLEXPA_PUBLISHABLE_KEY=

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,12 +1,7 @@
 {
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint"
-  ],
+  "plugins": ["@typescript-eslint"],
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "error",

--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -7,19 +7,13 @@
     <title>Flexpa Quickstart</title>
   </head>
   <body>
-    <div class='page-container'>
-      <div class='section-container'>
-          <h1>
-            Flexpa Quickstart
-          </h1>
+    <div class="page-container">
+      <div class="section-container">
+        <h1>Flexpa Quickstart</h1>
       </div>
-      <div class='section-container'>   
-          <div id="flexpa-link">
-    
-          </div>
-          <div id="coverage-container">
-
-          </div>
+      <div class="section-container">
+        <div id="flexpa-link"></div>
+        <div id="coverage-container"></div>
       </div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/client/src/coverage_display.ts
+++ b/client/src/coverage_display.ts
@@ -1,7 +1,7 @@
-import { Coverage, Patient } from 'fhir/r4';
+import { Coverage, Patient } from "fhir/r4";
 
 function displayCoverage(coverage: Coverage | undefined, patient: Patient) {
-  if (!coverage || coverage.resourceType !== 'Coverage') {
+  if (!coverage || coverage.resourceType !== "Coverage") {
     return /* html */ `
         <div>
         Error: Undefined Resource
@@ -15,7 +15,9 @@ function displayCoverage(coverage: Coverage | undefined, patient: Patient) {
       <dt>ID</dt>
       <dd>${coverage.id}</dd>
       <dt>Period</dt>
-      <dd>${coverage.period?.start ?? ""} ${`- ${coverage.period?.end}` ?? ""}</dd>
+      <dd>${coverage.period?.start ?? ""} ${
+        `- ${coverage.period?.end}` ?? ""
+      }</dd>
       <dt>Type</dt>
       <dd>${coverage.type?.text ?? ""}</dd>
       <dt>Relationship</dt>

--- a/client/src/flexpa_link_button.ts
+++ b/client/src/flexpa_link_button.ts
@@ -1,5 +1,5 @@
 function displayFlexpaLinkButton() {
-  return (/* html */`
+  return /* html */ `
     <div class="link-section">
         <div id="flexpa-link-btn" class="launch-btn">
             <span class="icon-container">
@@ -13,6 +13,6 @@ function displayFlexpaLinkButton() {
         &nbsp;<a href="https://www.flexpa.com/docs/getting-started/test-mode#test-mode-logins" target="_blank">test mode login</a>&nbsp; 
         to authenticate in the modal that appears.
     </div>
-    `);
+    `;
 }
 export default displayFlexpaLinkButton;

--- a/client/src/flexpa_types.d.ts
+++ b/client/src/flexpa_types.d.ts
@@ -7,5 +7,3 @@ export interface FlexpaConfig {
   publishableKey: string;
   onSuccess: (publicToken: string) => Promise | unknown;
 }
-
-

--- a/client/src/loading.ts
+++ b/client/src/loading.ts
@@ -1,5 +1,5 @@
 const loading = () => {
-  return ( /* html */ `
+  return /* html */ `
   <div class="loading">
     <svg
         role="status"
@@ -18,7 +18,7 @@ const loading = () => {
         />
     </svg>
   </div>
-  `);
+  `;
 };
 
 export default loading;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -12,30 +12,6 @@ declare const FlexpaLink: {
   open: () => Record<string, unknown>;
 };
 
-  /**
-   *  This function retries a fetch request if the response is a 429 Too Many Requests.
-   *  This is necessary because the Flexpa API may return a 429 if the data has not yet been loaded into the cache.
-   */
-async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 10) {
-  let retries = 0;
-  let delay = 1000;  // Initial delay is 1 second
-
-  while (retries < maxRetries) {
-    const response = await fetch(url, options);
-
-    if (response.status !== 429) {
-      return response;
-    }
-
-    const retryAfter = response.headers.get("Retry-After") || delay;
-    await new Promise(resolve => setTimeout(resolve, Number(retryAfter) * 1000));
-
-    retries++;
-    delay *= 2;  // Double the delay for exponential backoff
-  }
-
-  throw new Error("Max retries reached.");
-}
 
 
 function initializePage() {
@@ -111,7 +87,7 @@ function initializePage() {
       let fhirCoverageResp;
       let fhirCoverageBody: Bundle;
       try {
-         fhirCoverageResp = await fetchWithRetry(
+         fhirCoverageResp = await fetch(
           `${import.meta.env.VITE_SERVER_URL}/fhir/Coverage?patient=$PATIENT_ID`,
           {
             method: "GET",
@@ -137,7 +113,7 @@ function initializePage() {
       let fhirPatientResp;
       let fhirPatientBody: Patient;
       try {
-         fhirPatientResp = await fetchWithRetry(
+         fhirPatientResp = await fetch(
           `${import.meta.env.VITE_SERVER_URL}/fhir/Patient/$PATIENT_ID`,
           {
             method: "GET",

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -20,13 +20,8 @@ async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 10
   let retries = 0;
   let delay = 1000;  // Initial delay is 1 second
 
-  const augmentedHeaders = {
-    ...options.headers,
-    "x-flexpa-raw": "0"
-  };
-
   while (retries < maxRetries) {
-    const response = await fetch(url, {...options, headers: augmentedHeaders});
+    const response = await fetch(url, options);
 
     if (response.status !== 429) {
       return response;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -12,12 +12,10 @@ declare const FlexpaLink: {
   open: () => Record<string, unknown>;
 };
 
-
-
 function initializePage() {
   if (!import.meta.env.VITE_FLEXPA_PUBLISHABLE_KEY) {
     console.error(
-      "No publishable key found. Set VITE_FLEXPA_PUBLISHABLE_KEY in .env"
+      "No publishable key found. Set VITE_FLEXPA_PUBLISHABLE_KEY in .env",
     );
   }
   /**
@@ -39,7 +37,7 @@ function initializePage() {
               "content-type": "application/json",
             },
             body: JSON.stringify({ publicToken }),
-          }
+          },
         );
       } catch (err) {
         console.log("err", err);
@@ -87,14 +85,16 @@ function initializePage() {
       let fhirCoverageResp;
       let fhirCoverageBody: Bundle;
       try {
-         fhirCoverageResp = await fetch(
-          `${import.meta.env.VITE_SERVER_URL}/fhir/Coverage?patient=$PATIENT_ID`,
+        fhirCoverageResp = await fetch(
+          `${
+            import.meta.env.VITE_SERVER_URL
+          }/fhir/Coverage?patient=$PATIENT_ID`,
           {
             method: "GET",
             headers: {
               authorization: `Bearer ${accessToken}`,
             },
-          }
+          },
         );
         // Parse the Coverage response body
         fhirCoverageBody = await fhirCoverageResp.json();
@@ -113,14 +113,14 @@ function initializePage() {
       let fhirPatientResp;
       let fhirPatientBody: Patient;
       try {
-         fhirPatientResp = await fetch(
+        fhirPatientResp = await fetch(
           `${import.meta.env.VITE_SERVER_URL}/fhir/Patient/$PATIENT_ID`,
           {
             method: "GET",
             headers: {
               authorization: `Bearer ${accessToken}`,
             },
-          }
+          },
         );
         // Parse the Coverage response body
         fhirPatientBody = await fhirPatientResp.json();
@@ -133,11 +133,13 @@ function initializePage() {
         return;
       }
 
-
       /*  Display some information coverage information
           see https://www.hl7.org/fhir/coverage.html for available fields */
       const coverageHTMLs = fhirCoverageBody?.entry?.map((entry) =>
-        displayCoverage(entry.resource as Coverage | undefined, fhirPatientBody)
+        displayCoverage(
+          entry.resource as Coverage | undefined,
+          fhirPatientBody,
+        ),
       );
       const coverageListDiv = document.getElementById("coverage-list");
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -12,12 +12,21 @@ declare const FlexpaLink: {
   open: () => Record<string, unknown>;
 };
 
-async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 3) {
+  /**
+   *  This function retries a fetch request if the response is a 429 Too Many Requests.
+   *  This is necessary because the Flexpa API may return a 429 if the data has not yet been loaded into the cache.
+   */
+async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 10) {
   let retries = 0;
   let delay = 1000;  // Initial delay is 1 second
 
+  const augmentedHeaders = {
+    ...options.headers,
+    "x-flexpa-raw": "0"
+  };
+
   while (retries < maxRetries) {
-    const response = await fetch(url, options);
+    const response = await fetch(url, {...options, headers: augmentedHeaders});
 
     if (response.status !== 429) {
       return response;

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -52,15 +52,25 @@ html {
   justify-content: center;
   text-align: left;
   border: 0 solid #e5e7eb;
-  border-radius: .5rem;
+  border-radius: 0.5rem;
   background-color: rgb(255 255 255);
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .1), 0 1px 2px -1px rgba(0, 0, 0, .1);
+  box-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.1),
+    0 1px 2px -1px rgba(0, 0, 0, 0.1);
 }
 
 .code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    Liberation Mono,
+    Courier New,
+    monospace;
   font-size: 1em;
-  color: rgb(75 85 99)
+  color: rgb(75 85 99);
 }
 
 .table-heading {
@@ -136,7 +146,9 @@ dl {
   justify-items: baseline;
   padding: 16px;
   border-radius: 4px;
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 10%),
+    0 4px 6px -4px rgb(0 0 0 / 10%);
   background-color: white;
   margin-bottom: 24px;
   text-transform: capitalize;

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -24,6 +24,7 @@ html {
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  flex-direction: column;
 }
 
 .page-container {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,7 +15,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "skipLibCheck": true,
-    "types": ["vite/client"]  
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,7 +1,7 @@
 const viteConfig = {
   server: {
-    port: `3000`
+    port: `3000`,
   },
-  envDir: "."
+  envDir: ".",
 };
 export default viteConfig;

--- a/server/.env.template
+++ b/server/.env.template
@@ -2,6 +2,6 @@
 FLEXPA_PUBLIC_API_BASE_URL=https://api.flexpa.com
 
 # Add your Flexpa secret key here
-# You will be given two sets of publishable and secret keys, one for test mode and one for production. Be sure to enter the correct keys for your use case. 
+# You will be given two sets of publishable and secret keys, one for test mode and one for production. Be sure to enter the correct keys for your use case.
 # If test keys are used, a badge will appear on the Flexpa Link dialog indicating that the application is in test mode.
 FLEXPA_API_SECRET_KEY=

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,12 +1,7 @@
 {
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint"
-  ],
+  "plugins": ["@typescript-eslint"],
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "error",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,25 +1,24 @@
-import express from 'express';
-import bodyParser from 'body-parser';
-import cors from 'cors';
-import routes from './routes/flexpa_api_token.js';
-import fhirRouter from './routes/fhir.js';
-import 'dotenv/config';
+import express from "express";
+import bodyParser from "body-parser";
+import cors from "cors";
+import flexpaAccessToken from "./routes/flexpa_access_token.js";
+import fhirRouter from "./routes/fhir.js";
+import "dotenv/config";
+
 const app = express();
 
 /*  The frontend and backend servers run on different origins (localhost:3000 and localhost:9000 respectively).
     Without CORS handling, the browser will not allow the frontend to make requests to the backend.
     Use `cors()` to inject `Access-Control-Allow-Origin: *` header to preflight requests.
-    In a production environment it's important to handle this more intelligently (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+    In a production environment it's important to handle this intentionally (see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 */
 app.use(cors());
 
 // pre-parse the JSON body when appropriate
 app.use(bodyParser.json());
-app.use("", routes);
-app.use('/fhir', fhirRouter);
+app.use("/flexpa-access-token", flexpaAccessToken);
+app.use("/fhir", fhirRouter);
 
-
-app.listen(9000, '0.0.0.0', () => {
-  console.log('Server listening on http://localhost:9000');
+app.listen(9000, "0.0.0.0", () => {
+  console.log("Server listening on http://localhost:9000");
 });
-

--- a/server/src/routes/fhir.ts
+++ b/server/src/routes/fhir.ts
@@ -20,6 +20,7 @@ router.use("/", async (req: Request, res: Response) => {
       headers: {
         "content-type": "application/json",
         "Authorization": authorization,
+        "x-flexpa-raw": "0"
       }
     });
     const fhirBody: Bundle = await fhirResp.json();

--- a/server/src/routes/fhir.ts
+++ b/server/src/routes/fhir.ts
@@ -17,7 +17,7 @@ async function fetchWithRetry(
   let delay = 1;
   while (retries < maxRetries) {
     try {
-      console.log(`Fetching ${url}`);
+      console.log(`Fetching ${url}, retries: ${retries}`);
       const response = await fetch(url, {
         method: "GET",
         headers: {
@@ -49,7 +49,7 @@ async function fetchWithRetry(
  * Handles FHIR requests by proxying all requests to the patient's payer FHIR server via https://api.flexpa.com/fhir.
  * This router also appends the received URL path to the outbound request URL.
  */
-router.get("/", async (req: Request, res: Response) => {
+router.get("*", async (req: Request, res: Response) => {
   const { authorization } = req.headers;
   if (!authorization) {
     return res.status(401).send("All requests must be authenticated.");

--- a/server/src/routes/fhir.ts
+++ b/server/src/routes/fhir.ts
@@ -1,5 +1,5 @@
-import {Bundle} from "fhir/r4";
-import express, {Request, Response, Router} from "express";
+import { Bundle } from "fhir/r4";
+import express, { Request, Response, Router } from "express";
 import fetch from "node-fetch";
 
 const router: Router = express.Router();
@@ -46,9 +46,10 @@ async function fetchWithRetry(
 }
 
 /**
- * Handles FHIR requests by proxying all requests to the patient's payer FHIR server via https://api.flexpa.com/fhir. This router also appends the received URL path to the outbound request URL.
+ * Handles FHIR requests by proxying all requests to the patient's payer FHIR server via https://api.flexpa.com/fhir.
+ * This router also appends the received URL path to the outbound request URL.
  */
-router.use("/", async (req: Request, res: Response) => {
+router.get("/", async (req: Request, res: Response) => {
   const { authorization } = req.headers;
   if (!authorization) {
     return res.status(401).send("All requests must be authenticated.");

--- a/server/src/routes/fhir.ts
+++ b/server/src/routes/fhir.ts
@@ -1,37 +1,71 @@
-import express, { Router, Request, Response } from 'express';
-import fetch from 'node-fetch';
-import { Bundle } from 'fhir/r4';
-
+import express, { Router, Request, Response } from "express";
+import fetch from "node-fetch";
+import { Bundle } from "fhir/r4";
 
 const router: Router = express.Router();
+
+/**
+ *  This function retries a fetch request if the response is a 429 Too Many Requests.
+ *  This is necessary because the Flexpa API may return a 429 if the data has not yet been loaded into the cache.
+ */
+async function fetchWithRetry(
+  url: string,
+  authorization: string,
+  maxRetries = 10
+) {
+  let retries = 0;
+  let delay = 1;
+  while (retries < maxRetries) {
+    try {
+      console.log(`Fetching ${url}`);
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          "content-type": "application/json",
+          Authorization: authorization,
+          "x-flexpa-raw": "0",
+        },
+      });
+      if (response.status !== 429) {
+        console.log(`Received ${response.status} from ${url}`);
+        return response;
+      }
+      const retryAfter = response.headers.get("Retry-After") || delay;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Number(retryAfter) * 1000)
+      );
+      retries++;
+      delay *= 2; // Double the delay for exponential backoff
+    } catch (err) {
+      console.log(`Error fetching ${url}: ${err}`);
+      throw err;
+    }
+  }
+
+  throw new Error("Max retries reached.");
+}
 
 /**
  * Handles FHIR requests by proxying all requests to the patient's payer FHIR server via https://api.flexpa.com/fhir. This router also appends the received URL path to the outbound request URL.
  */
 router.use("/", async (req: Request, res: Response) => {
-    const { authorization } = req.headers;
-    const { path } = req;
-    if (!authorization) return res.status(401).send('All requests must be authenticated.');
+  const { authorization } = req.headers;
+  const { path } = req;
+  if (!authorization)
+    return res.status(401).send("All requests must be authenticated.");
 
   // Call Flexpa FHIR API
   try {
-    const fhirResp = await fetch(`${process.env.FLEXPA_PUBLIC_API_BASE_URL}/fhir${path}`, {
-      method: "GET",
-      headers: {
-        "content-type": "application/json",
-        "Authorization": authorization,
-        "x-flexpa-raw": "0"
-      }
-    });
+    const fhirResp = await fetchWithRetry(
+      `${process.env.FLEXPA_PUBLIC_API_BASE_URL}/fhir${path}`,
+      authorization
+    );
     const fhirBody: Bundle = await fhirResp.json();
     res.send(fhirBody);
-  }
-  catch (err) {
+  } catch (err) {
     console.log(`Error retrieving FHIR: ${err}`);
     return res.status(500).send(`Error retrieving FHIR: ${err}`);
   }
-
 });
-
 
 export default router;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     /* Visit https://www.typescriptlang.org/tsconfig to read more about this file */
-    "target": "es6",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
-    "rootDir": "./src",
+    "target": "es6" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    "rootDir": "./src"
   }
 }


### PR DESCRIPTION
## Why
* Flexpa is switching to our new cache based infrastructure, which will return 429s when the data isn't loaded
* The quickstart should use this new infrastructure and handle 429s gracefully

## What
* Routes FHIR requests to the new infrastructure
* Handles 429s gracefully
* Fixes a minor bug with centering text:
<img width="1182" alt="image" src="https://github.com/flexpa/quickstart/assets/68571760/aebffcba-08db-42ca-915f-152fed207bc9">
