### PR TITLE
feat: add a root level package.json with a stackblitz start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@flexpa/quickstart",
+  "private": true,
+  "version": "1.0.0",
+  "description": "This repository is a companion to Flexpa's [quickstart guide](https://www.flexpa.com/docs/guides/quickstart) which also provides a detailed explanation of how this code example works. Please use our [community discussions](https://github.com/flexpa/community/discussions) for support and issues with this code.",
+  "stackblitz": {
+    "startCommand": "(cd client && npm ci && npm run dev) & (cd server && npm ci && npm run dev)"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
## Why

We want to experiment with a living example in our docs, and use this repo to give new developers a tactile example as soon as they land in the quickstart guide

## What

Adds a root level package.json with a stackblitz.startCommand.