### PR TITLE
fix(quickstart): add required usage parameter

### DIFF
--- a/client/src/flexpa_types.d.ts
+++ b/client/src/flexpa_types.d.ts
@@ -8,5 +8,6 @@ export interface FlexpaConfig {
   user: {
     externalId: string;
   };
+  usage: 'ONE_TIME';
   onSuccess: (publicToken: string) => Promise | unknown;
 }

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -27,6 +27,7 @@ function initializePage() {
     user: {
       externalId: 'usr_1234'
     },
+    usage: 'ONE_TIME',
     onSuccess: async (publicToken: string) => {
       /*  Make a request to the `POST /flexpa-access-token` endpoint that we wrote in `server`.
           include the `publicToken` in the body. */


### PR DESCRIPTION
## Why
- We haven't updated quickstart since we added the required `usage` parameter.

## What
- Add `usage` parameter to `FlexpaLInk.create`