### PR TITLE
fix(quickstart): add usage param

### DIFF
--- a/src/components/launch-link.tsx
+++ b/src/components/launch-link.tsx
@@ -11,6 +11,7 @@ export function LaunchLink() {
   function open() {
     FlexpaLink.create({
       publishableKey: process.env.NEXT_PUBLIC_FLEXPA_PUBLISHABLE_KEY!,
+      usage: 'ONE_TIME',
       user: { externalId: crypto.randomUUID() },
       onSuccess: async (publicToken: string) => {
         await fetch('/api/exchange', { method: 'POST', body: JSON.stringify({ publicToken }) })


### PR DESCRIPTION
## Why

- Usage is required

## What

- Add usage to FlexpaLink.create
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `usage: 'ONE_TIME'` parameter to `FlexpaLink.create` in `launch-link.tsx`.
> 
>   - **Behavior**:
>     - Add `usage: 'ONE_TIME'` parameter to `FlexpaLink.create` in `launch-link.tsx` to ensure proper usage configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexpa%2Fquickstart&utm_source=github&utm_medium=referral)<sup> for 3f1d4d21c8fb8e5d3d360661e4cc27bf9131e219. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->