### PR TITLE
feat(quickstart): search mode + portal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You must generate a random value for `SESSION_SECRET` in `.env`. One way is to u
 openssl rand -base64 32
 ```
 
+Create your API keys at [portal.flexpa.com](https://portal.flexpa.com) and copy the publishable and secret keys into `.env`. Then back in the Flexpa portal, click application settings and register `http://localhost:3000/callback` as an allowed redirect URI.
+
 ## Development
 
 To run the project:

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -15,6 +15,7 @@ export async function startOAuthFlow() {
     redirectUri: env.redirectUri,
     codeChallenge,
     externalId: crypto.randomUUID(),
+    _experimentalParams: { flexpa_search_mode: 'true' },
   });
 
   return authUrl;


### PR DESCRIPTION
## Why
Surface the search-mode consent experience in the quickstart, and give new users explicit setup steps for the Flexpa portal so the OAuth flow works end-to-end.

## What
- Pass `flexpa_search_mode: 'true'` via `_experimentalParams` in `startOAuthFlow` so the hosted Link flow opens in search mode.
- README: after the `SESSION_SECRET` step, document creating API keys at portal.flexpa.com and registering `http://localhost:3000/callback` as an allowed redirect URI.
- NOTE: we should move the search mode out of experimental params as a next step to avoid confusion. We should also implement TEFCA and more options to query provider-type resources. But this at least gets us the new flow. 