### PR TITLE
feat(quickstart): TEFCA document support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "ai": "^6.0.97",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.4.8",
         "jose": "^5.10.0",
         "lucide-react": "^0.454.0",
         "next": "^15.5.18",
@@ -1944,6 +1945,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2313,6 +2321,15 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ai-sdk/anthropic": "^3.0.46",
         "@ai-sdk/openai": "^3.0.30",
         "@ai-sdk/react": "^3.0.99",
-        "@flexpa/node-sdk": "^1.0.0",
+        "@flexpa/node-sdk": "^2.0.0",
         "@medplum/core": "^3.3.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-scroll-area": "^1.2.10",
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@flexpa/node-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@flexpa/node-sdk/-/node-sdk-1.0.0.tgz",
-      "integrity": "sha512-wYXl5ePU+Ixx/4PXjUUoS9kIx7fv24T1vdt9qxCzzuxcCqpjMfuYJYCmDM44ZNKeSe0w7mkin+Rh6mTPRLwsxQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@flexpa/node-sdk/-/node-sdk-2.0.0.tgz",
+      "integrity": "sha512-xduf7VDIBuoiQZjrMrIgcDtrCnf0Q55CqfmjkgldtH4pl6ebbsREViBKFzBDMso0RQ+PZuRyRlQY/oGlPdPVVw=="
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@ai-sdk/anthropic": "^3.0.46",
     "@ai-sdk/openai": "^3.0.30",
     "@ai-sdk/react": "^3.0.99",
-    "@flexpa/node-sdk": "^1.0.0",
+    "@flexpa/node-sdk": "^2.0.0",
     "@medplum/core": "^3.3.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-scroll-area": "^1.2.10",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ai": "^6.0.97",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.4.8",
     "jose": "^5.10.0",
     "lucide-react": "^0.454.0",
     "next": "^15.5.18",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -57,31 +57,6 @@ export default async function Dashboard() {
             patientAuthorizationsError={consentData === null}
           />
 
-          {/* Parsed Records Card */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <div>
-                  <CardTitle>Parsed Records</CardTitle>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    <Link
-                      href="https://www.flexpa.com/docs/guides/parsing-fhir"
-                      className="underline"
-                    >
-                      ViewDefinitions
-                    </Link>{' '}
-                    transform complex FHIR resources into flat, tabular data
-                    &mdash; no parsing code required. Select a ViewDefinition
-                    below and run it against the patient&apos;s data.
-                  </p>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <ParsedRecords />
-            </CardContent>
-          </Card>
-
           {/* API Explorer Card */}
           <Card>
             <CardHeader>
@@ -155,6 +130,31 @@ export default async function Dashboard() {
 
                 <ApiRequests />
               </div>
+            </CardContent>
+          </Card>
+
+          {/* Parsed Records Card */}
+          <Card>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>Parsed Records</CardTitle>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    <Link
+                      href="https://www.flexpa.com/docs/guides/parsing-fhir"
+                      className="underline"
+                    >
+                      ViewDefinitions
+                    </Link>{' '}
+                    transform complex FHIR resources into flat, tabular data
+                    &mdash; no parsing code required. Select a ViewDefinition
+                    below and run it against the patient&apos;s data.
+                  </p>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <ParsedRecords />
             </CardContent>
           </Card>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ExternalLink, Search, ShieldCheck } from 'lucide-react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -12,9 +13,18 @@ import {
 import { type ConsentFlow, startOAuthFlow } from '@/lib/oauth';
 
 export default function Home() {
+  const [error, setError] = useState<string | null>(null);
+
   async function handleConnect(flow: ConsentFlow) {
-    const authUrl = await startOAuthFlow(flow);
-    window.location.href = authUrl;
+    try {
+      const authUrl = await startOAuthFlow(flow);
+      window.location.href = authUrl;
+    } catch (err) {
+      console.error('Failed to start OAuth flow', err);
+      setError(
+        "Couldn't start the connection. Check your Flexpa keys and try again.",
+      );
+    }
   }
 
   return (
@@ -72,6 +82,8 @@ export default function Home() {
             </CardFooter>
           </Card>
         </div>
+
+        {error && <p className="text-red-600 mt-6 text-sm">{error}</p>}
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,9 +37,11 @@ export default function Home() {
               <CardTitle className="text-xl">Search</CardTitle>
               <CardDescription>
                 The patient searches by health plan, provider, or facility and
-                connects to each one directly. They can link several sources in
-                a single session, with no identity verification step. Best when
-                they already know where their records live.
+                connects to each one directly across health insurer (CMS-9115)
+                and medical record system (ONC (g)(10)) networks. They can link
+                several sources in a single session, with no identity
+                verification step. Best when they already know where their
+                records live.
               </CardDescription>
             </CardHeader>
             <CardFooter className="mt-auto">
@@ -57,9 +59,10 @@ export default function Home() {
               </CardTitle>
               <CardDescription>
                 The patient verifies their identity once with CLEAR, ID.me, or
-                Persona. Flexpa then automatically finds and connects their
-                records across tens of thousands of facilities nationwide. Best
-                for broad coverage without hunting down each source.
+                Persona. Flexpa then uses the TEFCA nationwide network (via the
+                CommonWell and Kno2 QHINs) to automatically find and connect
+                their records across tens of thousands of facilities. Best for
+                broad coverage without hunting down each source.
               </CardDescription>
             </CardHeader>
             <CardFooter className="mt-auto">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null);
 
   async function handleConnect(flow: ConsentFlow) {
+    setError(null);
     try {
       const authUrl = await startOAuthFlow(flow);
       window.location.href = authUrl;
@@ -83,7 +84,11 @@ export default function Home() {
           </Card>
         </div>
 
-        {error && <p className="text-red-600 mt-6 text-sm">{error}</p>}
+        {error && (
+          <p role="alert" className="text-red-600 mt-6 text-sm">
+            {error}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,74 @@
 'use client';
 
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Search, ShieldCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { startOAuthFlow } from '@/lib/oauth';
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { type ConsentFlow, startOAuthFlow } from '@/lib/oauth';
 
 export default function Home() {
-  async function handleConnect() {
-    const authUrl = await startOAuthFlow();
+  async function handleConnect(flow: ConsentFlow) {
+    const authUrl = await startOAuthFlow(flow);
     window.location.href = authUrl;
   }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-white">
-      <div className="max-w-2xl mx-auto px-4">
+      <div className="max-w-4xl mx-auto px-4 py-12">
         <h1 className="text-4xl font-bold mb-2">Flexpa Quickstart</h1>
         <p className="text-xl mb-6">
           A sample end-to-end integration with Flexpa
         </p>
         <p className="text-gray-600 mb-8">
           The Flexpa consent flow begins when your user wants to connect their
-          health insurance to your app. Click the button below to start the
-          OAuth authorization flow - you will be redirected to Flexpa where you
-          can select your health plan and authorize access to your claims data.
+          health data to your app. Choose how they start below. Either way they
+          are redirected to Flexpa to authorize access, then sent back here.
         </p>
-        <Button onClick={handleConnect}>
-          Launch Consent <ExternalLink className="ml-2 h-4 w-4" />
-        </Button>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card className="flex flex-col">
+            <CardHeader>
+              <Search className="h-6 w-6 mb-2 text-gray-700" />
+              <CardTitle className="text-xl">Search</CardTitle>
+              <CardDescription>
+                The patient searches by health plan, provider, or facility and
+                connects to each one directly. They can link several sources in
+                a single session, with no identity verification step. Best when
+                they already know where their records live.
+              </CardDescription>
+            </CardHeader>
+            <CardFooter className="mt-auto">
+              <Button onClick={() => handleConnect('search')}>
+                Launch Search <ExternalLink className="ml-2 h-4 w-4" />
+              </Button>
+            </CardFooter>
+          </Card>
+
+          <Card className="flex flex-col">
+            <CardHeader>
+              <ShieldCheck className="h-6 w-6 mb-2 text-gray-700" />
+              <CardTitle className="text-xl">
+                Identity verification (IAL2)
+              </CardTitle>
+              <CardDescription>
+                The patient verifies their identity once with CLEAR, ID.me, or
+                Persona. Flexpa then automatically finds and connects their
+                records across tens of thousands of facilities nationwide. Best
+                for broad coverage without hunting down each source.
+              </CardDescription>
+            </CardHeader>
+            <CardFooter className="mt-auto">
+              <Button onClick={() => handleConnect('ial2')}>
+                Verify Identity <ExternalLink className="ml-2 h-4 w-4" />
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/src/components/api-requests/coverage.tsx
+++ b/src/components/api-requests/coverage.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { handleCopyJson } from '@/components/api-requests';
+import { EmptyResults } from '@/components/api-requests/empty-results';
 import { CurlExample } from '@/components/curl-example';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -190,6 +191,14 @@ export default function CoverageRequest() {
             </TabsContent>
           </Tabs>
         </div>
+      )}
+
+      {coverageData && !coverageData.entry?.length && (
+        <EmptyResults
+          message="No insurance plans found."
+          onRetry={handleCoverageRequest}
+          isLoading={isLoading}
+        />
       )}
     </div>
   );

--- a/src/components/api-requests/document-attachment.tsx
+++ b/src/components/api-requests/document-attachment.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import type { Attachment, DocumentReference } from 'fhir/r4';
+import { Download, ExternalLink, FileText } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { NarrativeHtml } from '@/components/api-requests/narrative-html';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  type CcdaDocument,
+  decodeBase64,
+  isTextContentType,
+  normalizeBase64,
+  parseCcda,
+} from '@/lib/ccda';
+
+type ViewMode = 'none' | 'text' | 'ccda';
+
+/**
+ * Renders the attachments of a DocumentReference (content[].attachment) with
+ * affordances to view the underlying document: a structured C-CDA viewer for
+ * XML, decoded text for other text formats, plus download/open-link actions.
+ */
+export function DocumentAttachments({
+  document,
+}: {
+  document: DocumentReference;
+}) {
+  const content = document.content ?? [];
+
+  if (!content.length) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No attachment content available.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {content.map((entry, index) => (
+        <AttachmentViewer
+          key={`${document.id ?? 'document'}-${index}`}
+          attachment={entry.attachment}
+          index={index}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AttachmentViewer({
+  attachment,
+  index,
+}: {
+  attachment?: Attachment;
+  index: number;
+}) {
+  const [view, setView] = useState<ViewMode>('none');
+
+  const decodedText = useMemo(() => {
+    if (view !== 'text' || !attachment?.data) return undefined;
+    return decodeBase64(attachment.data);
+  }, [view, attachment?.data]);
+
+  const ccda = useMemo<CcdaDocument | undefined>(() => {
+    if (view !== 'ccda' || !attachment?.data || typeof window === 'undefined') {
+      return undefined;
+    }
+    const decoded = decodeBase64(attachment.data);
+    if (!decoded) {
+      return {
+        title: 'C-CDA Document',
+        sections: [],
+        error: 'Unable to decode attachment data.',
+      };
+    }
+    return parseCcda(decoded);
+  }, [view, attachment?.data]);
+
+  // Only link out to absolute http(s) URLs. Relative attachment URLs (e.g.
+  // `Binary/123`) can't be resolved here: the quickstart has no Binary proxy
+  // and a raw browser request wouldn't carry the session's bearer token.
+  const externalUrl = useMemo(() => {
+    if (!attachment?.url) return undefined;
+    try {
+      const parsed = new URL(attachment.url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+        ? parsed.toString()
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }, [attachment?.url]);
+
+  if (!attachment) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Attachment details unavailable.
+      </p>
+    );
+  }
+
+  const contentType = (attachment.contentType || 'application/octet-stream')
+    .trim()
+    .toLowerCase();
+  const isXml = contentType.includes('xml');
+  const isText = isTextContentType(contentType);
+  const dataUrl = attachment.data
+    ? `data:${contentType};base64,${normalizeBase64(attachment.data)}`
+    : undefined;
+
+  const toggle = (mode: ViewMode) =>
+    setView((prev) => (prev === mode ? 'none' : mode));
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <div className="text-sm font-medium">
+            {attachment.title || `Attachment ${index + 1}`}
+          </div>
+          <div className="font-mono text-xs text-muted-foreground">
+            {contentType}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {attachment.data && isXml && (
+          <Button
+            size="sm"
+            variant={view === 'ccda' ? 'secondary' : 'outline'}
+            onClick={() => toggle('ccda')}
+          >
+            <FileText className="h-4 w-4" />
+            {view === 'ccda' ? 'Hide document' : 'View document'}
+          </Button>
+        )}
+        {attachment.data && isText && (
+          <Button
+            size="sm"
+            variant={view === 'text' ? 'secondary' : 'outline'}
+            onClick={() => toggle('text')}
+          >
+            {view === 'text' ? 'Hide text' : 'View text'}
+          </Button>
+        )}
+        {dataUrl && (
+          <Button asChild size="sm" variant="outline">
+            <a
+              href={dataUrl}
+              download={attachment.title || `document-attachment-${index + 1}`}
+            >
+              <Download className="h-4 w-4" />
+              Download
+            </a>
+          </Button>
+        )}
+        {/* Only offer "Open link" when there's no inline data. With inline
+            data the content is available locally (View/Download cover it), and
+            the url can be a raw upstream Binary endpoint that 401s on a plain
+            browser request. Without inline data the url is the only path, and
+            per the docs Flexpa serves a signed binary.flexpa.com URL that needs
+            no Authorization header. */}
+        {!attachment.data && externalUrl && (
+          <Button asChild size="sm" variant="outline">
+            <a href={externalUrl} target="_blank" rel="noreferrer">
+              <ExternalLink className="h-4 w-4" />
+              Open link
+            </a>
+          </Button>
+        )}
+        {!attachment.data && !externalUrl && (
+          <span className="text-xs text-muted-foreground">
+            No viewable content.
+          </span>
+        )}
+      </div>
+
+      {view === 'text' && (
+        <ScrollArea className="h-72 rounded-md border">
+          <pre className="whitespace-pre-wrap p-3 font-mono text-xs">
+            {decodedText ?? 'Unable to decode attachment data.'}
+          </pre>
+        </ScrollArea>
+      )}
+
+      {view === 'ccda' && <CcdaViewer document={ccda} />}
+    </div>
+  );
+}
+
+function CcdaViewer({ document }: { document?: CcdaDocument }) {
+  if (!document) return null;
+
+  if (document.error) {
+    return <p className="text-xs text-destructive">{document.error}</p>;
+  }
+
+  if (!document.sections.length) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No sections found in this document.
+      </p>
+    );
+  }
+
+  return (
+    <div className="rounded-md border">
+      <div className="border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
+        {document.title} · {document.sections.length} sections
+      </div>
+      <ScrollArea className="h-96">
+        <Accordion type="single" collapsible className="px-3">
+          {document.sections.map((section) => (
+            <AccordionItem key={section.id} value={section.id}>
+              <AccordionTrigger className="py-3 text-sm">
+                <span className="text-left">
+                  {section.title}
+                  {section.display && (
+                    <span className="block text-xs font-normal text-muted-foreground">
+                      {section.display}
+                    </span>
+                  )}
+                </span>
+              </AccordionTrigger>
+              <AccordionContent>
+                {section.html ? (
+                  <NarrativeHtml
+                    html={section.html}
+                    className="overflow-x-auto text-xs text-gray-700 [&_p]:my-2 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-gray-200 [&_td]:px-2 [&_td]:py-1 [&_th]:border [&_th]:border-gray-200 [&_th]:bg-gray-50 [&_th]:px-2 [&_th]:py-1"
+                  />
+                ) : section.text ? (
+                  <div className="whitespace-pre-wrap text-xs text-muted-foreground">
+                    {section.text}
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground">
+                    No narrative text for this section.
+                  </div>
+                )}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/src/components/api-requests/empty-results.tsx
+++ b/src/components/api-requests/empty-results.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Inbox } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface EmptyResultsProps {
+  message: string;
+  onRetry: () => void;
+  isLoading: boolean;
+}
+
+export function EmptyResults({
+  message,
+  onRetry,
+  isLoading,
+}: EmptyResultsProps) {
+  return (
+    <div className="flex flex-col items-start gap-3 rounded-md border border-dashed p-6">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Inbox className="h-4 w-4" />
+        <span>{message}</span>
+      </div>
+      <Button
+        variant="outline"
+        onClick={onRetry}
+        disabled={isLoading}
+        className="min-w-[120px]"
+      >
+        {isLoading ? 'Loading...' : 'Send Request'}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/api-requests/eob.tsx
+++ b/src/components/api-requests/eob.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { handleCopyJson } from '@/components/api-requests';
+import { EmptyResults } from '@/components/api-requests/empty-results';
 import { CurlExample } from '@/components/curl-example';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -196,6 +197,14 @@ export default function EobRequest() {
             </TabsContent>
           </Tabs>
         </div>
+      )}
+
+      {eobData && !eobData.entry?.length && (
+        <EmptyResults
+          message="No claims found."
+          onRetry={handleEobRequest}
+          isLoading={isLoading}
+        />
       )}
     </div>
   );

--- a/src/components/api-requests/everything.tsx
+++ b/src/components/api-requests/everything.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Bundle, FhirResource } from 'fhir/r4';
+import type { Bundle, DocumentReference, FhirResource } from 'fhir/r4';
 import {
   ArrowRight,
   Check,
@@ -13,11 +13,20 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { handleCopyJson } from '@/components/api-requests';
+import { DocumentAttachments } from '@/components/api-requests/document-attachment';
+import { EmptyResults } from '@/components/api-requests/empty-results';
 import { CurlExample } from '@/components/curl-example';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
@@ -43,9 +52,7 @@ const getResourceInfo = (bundle: Bundle): ResourceInfo[] => {
     const info = resourceMap.get(resource.resourceType);
     if (info) {
       info.count++;
-      if (info.examples.length < 3) {
-        info.examples.push(resource);
-      }
+      info.examples.push(resource);
     } else {
       resourceMap.set(resource.resourceType, {
         count: 1,
@@ -199,33 +206,70 @@ export default function Everything() {
                     )}
                   </Button>
                   {selectedResource.examples.length > 1 && (
-                    <div className="flex gap-1">
-                      {selectedResource.examples.map((example, idx) => (
-                        <Button
-                          key={`example-${example.resourceType}-${idx}`}
-                          variant={
-                            selectedExample === idx ? 'secondary' : 'ghost'
-                          }
-                          size="sm"
-                          onClick={() => setSelectedExample(idx)}
-                        >
-                          #{idx + 1}
-                        </Button>
-                      ))}
-                    </div>
+                    <Select
+                      value={String(selectedExample)}
+                      onValueChange={(value) =>
+                        setSelectedExample(Number(value))
+                      }
+                    >
+                      <SelectTrigger className="w-[200px] font-mono text-xs">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {selectedResource.examples.map((example, idx) => (
+                          <SelectItem
+                            key={`example-${example.resourceType}-${idx}`}
+                            value={String(idx)}
+                            className="font-mono text-xs"
+                          >
+                            #{idx + 1}
+                            {example.id ? `  ${example.id}` : ''}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   )}
                 </div>
               </div>
             </div>
-            <ScrollArea className="h-[500px] rounded-md border p-4">
-              <pre className="text-sm font-mono whitespace-pre-wrap">
-                {JSON.stringify(
-                  selectedResource.examples[selectedExample],
-                  null,
-                  2,
-                )}
-              </pre>
-            </ScrollArea>
+            {selectedResource.type === 'DocumentReference' ? (
+              <Tabs defaultValue="document" className="w-full">
+                <TabsList>
+                  <TabsTrigger value="document">Document</TabsTrigger>
+                  <TabsTrigger value="json">Resource</TabsTrigger>
+                </TabsList>
+                <TabsContent value="document" className="mt-3">
+                  <DocumentAttachments
+                    document={
+                      selectedResource.examples[
+                        selectedExample
+                      ] as DocumentReference
+                    }
+                  />
+                </TabsContent>
+                <TabsContent value="json" className="mt-3">
+                  <ScrollArea className="h-[460px] rounded-md border p-4">
+                    <pre className="text-sm font-mono whitespace-pre-wrap">
+                      {JSON.stringify(
+                        selectedResource.examples[selectedExample],
+                        null,
+                        2,
+                      )}
+                    </pre>
+                  </ScrollArea>
+                </TabsContent>
+              </Tabs>
+            ) : (
+              <ScrollArea className="h-[500px] rounded-md border p-4">
+                <pre className="text-sm font-mono whitespace-pre-wrap">
+                  {JSON.stringify(
+                    selectedResource.examples[selectedExample],
+                    null,
+                    2,
+                  )}
+                </pre>
+              </ScrollArea>
+            )}
           </div>
         )}
       </div>
@@ -265,7 +309,7 @@ export default function Everything() {
         </Button>
       )}
 
-      {everythingData && (
+      {everythingData?.entry?.length ? (
         <div className="space-y-4">
           <div className="flex items-center gap-2">
             <h3 className="font-semibold">Response Overview</h3>
@@ -326,7 +370,13 @@ export default function Everything() {
             </TabsContent>
           </Tabs>
         </div>
-      )}
+      ) : everythingData ? (
+        <EmptyResults
+          message="No records returned."
+          onRetry={handleEverythingRequest}
+          isLoading={isLoading}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/api-requests/narrative-html.tsx
+++ b/src/components/api-requests/narrative-html.tsx
@@ -1,0 +1,14 @@
+// biome-ignore-all lint/security/noDangerouslySetInnerHtml: input is C-CDA narrative already sanitized via sanitizeNarrativeHtml (allowlist tags/attrs, strips scripts and unsafe URLs)
+
+/** Renders pre-sanitized narrative HTML (e.g. a C-CDA section). */
+export function NarrativeHtml({
+  html,
+  className,
+}: {
+  html: string;
+  className?: string;
+}) {
+  return (
+    <div className={className} dangerouslySetInnerHTML={{ __html: html }} />
+  );
+}

--- a/src/components/api-requests/patient.tsx
+++ b/src/components/api-requests/patient.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { handleCopyJson } from '@/components/api-requests';
+import { EmptyResults } from '@/components/api-requests/empty-results';
 import { CurlExample } from '@/components/curl-example';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -86,7 +87,7 @@ export default function PatientRequest() {
         </Button>
       )}
 
-      {patientData && (
+      {patientData?.resourceType === 'Patient' && (
         <div className="space-y-4">
           <div className="flex items-center gap-2">
             <h3 className="font-semibold">Response Overview</h3>
@@ -203,6 +204,14 @@ export default function PatientRequest() {
             </TabsContent>
           </Tabs>
         </div>
+      )}
+
+      {patientData && patientData.resourceType !== 'Patient' && (
+        <EmptyResults
+          message="No patient record found."
+          onRetry={handlePatientRequest}
+          isLoading={isLoading}
+        />
       )}
     </div>
   );

--- a/src/lib/ccda.ts
+++ b/src/lib/ccda.ts
@@ -104,10 +104,9 @@ export function parseCcda(xml: string): CcdaDocument {
       },
     );
 
-    const orderedSections = sections
-      .map((section, position) => ({ ...section, position }))
-      .sort((a, b) => a.title.localeCompare(b.title))
-      .map(({ position: _position, ...section }) => section);
+    const orderedSections = [...sections].sort((a, b) =>
+      a.title.localeCompare(b.title),
+    );
 
     return { title, sections: orderedSections };
   } catch {

--- a/src/lib/ccda.ts
+++ b/src/lib/ccda.ts
@@ -1,0 +1,130 @@
+// Helpers for decoding base64 FHIR attachment payloads and parsing C-CDA XML
+// documents (the format Flexpa returns for clinical documents during IAL2 /
+// TEFCA authorizations) into navigable narrative sections. Browser-only.
+
+import { sanitizeNarrativeHtml } from './sanitize-narrative-html';
+
+export interface CcdaSection {
+  id: string;
+  title: string;
+  code?: string;
+  display?: string;
+  html?: string;
+  text?: string;
+}
+
+export interface CcdaDocument {
+  title: string;
+  sections: CcdaSection[];
+  error?: string;
+}
+
+/**
+ * Normalize base64 payloads coming off the wire so they decode cleanly via
+ * `atob` and embed correctly in `data:` URLs.
+ *
+ * Steps:
+ *   1. Convert URL-safe base64 (`-`/`_`) to standard base64 (`+`/`/`).
+ *   2. Strip characters that are not valid base64 (whitespace, dots, and
+ *      other garbage some payers inject into encoded payloads).
+ *   3. Remove existing padding before recalculating it, so malformed
+ *      padding doesn't cascade into decode failures.
+ */
+export function normalizeBase64(data: string): string {
+  let normalized = data.replace(/-/g, '+').replace(/_/g, '/');
+  normalized = normalized.replace(/[^A-Za-z0-9+/=]/g, '');
+  const unpadded = normalized.replace(/=+$/, '');
+  const padding = unpadded.length % 4;
+  return padding ? `${unpadded}${'='.repeat(4 - padding)}` : unpadded;
+}
+
+export function decodeBase64(data: string): string | undefined {
+  try {
+    const binary = atob(normalizeBase64(data));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder('utf-8').decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseCcda(xml: string): CcdaDocument {
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xml, 'text/xml');
+    const parseError = doc.getElementsByTagName('parsererror')[0];
+    if (parseError) {
+      return {
+        title: 'C-CDA Document',
+        sections: [],
+        error: 'Unable to parse XML.',
+      };
+    }
+
+    const clinicalDocument = doc.getElementsByTagName('ClinicalDocument')[0];
+    const title =
+      clinicalDocument?.getElementsByTagName('title')[0]?.textContent?.trim() ||
+      'C-CDA Document';
+    const serializer = new XMLSerializer();
+
+    const sections = Array.from(doc.getElementsByTagName('section')).map(
+      (section, index) => {
+        const titleNode = section.getElementsByTagName('title')[0];
+        const codeNode = section.getElementsByTagName('code')[0];
+        const textNode = section.getElementsByTagName('text')[0];
+        const rawHtml = textNode
+          ? serializer.serializeToString(textNode)
+          : undefined;
+        const html = rawHtml
+          ? sanitizeNarrativeHtml(
+              rawHtml
+                .replace(/^<text[^>]*>/i, '')
+                .replace(/<\/text>$/i, '')
+                .replace(/<paragraph/gi, '<p')
+                .replace(/<\/paragraph>/gi, '</p>')
+                .replace(/<content/gi, '<span')
+                .replace(/<\/content>/gi, '</span>'),
+            )
+          : undefined;
+        const code = codeNode?.getAttribute('code') || undefined;
+        const display = codeNode?.getAttribute('displayName') || undefined;
+        const text = section.textContent?.replace(/\s+/g, ' ').trim();
+
+        return {
+          id: `section-${index}`,
+          title: titleNode?.textContent?.trim() || `Section ${index + 1}`,
+          ...(code ? { code } : {}),
+          ...(display ? { display } : {}),
+          ...(html ? { html } : {}),
+          ...(text ? { text } : {}),
+        };
+      },
+    );
+
+    const orderedSections = sections
+      .map((section, position) => ({ ...section, position }))
+      .sort((a, b) => a.title.localeCompare(b.title))
+      .map(({ position: _position, ...section }) => section);
+
+    return { title, sections: orderedSections };
+  } catch {
+    return {
+      title: 'C-CDA Document',
+      sections: [],
+      error: 'Unable to parse XML.',
+    };
+  }
+}
+
+export function isTextContentType(contentType?: string | null): boolean {
+  return Boolean(
+    contentType &&
+      (contentType.startsWith('text/') ||
+        contentType.includes('json') ||
+        contentType.includes('xml') ||
+        contentType.includes('html')),
+  );
+}

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -5,8 +5,8 @@ import { env } from './env';
 import { setCodeVerifier } from './session';
 
 export async function startOAuthFlow() {
-  const codeVerifier = FlexpaClient.generateCodeVerifier();
-  const codeChallenge = FlexpaClient.generateCodeChallenge(codeVerifier);
+  const codeVerifier = await FlexpaClient.generateCodeVerifier();
+  const codeChallenge = await FlexpaClient.generateCodeChallenge(codeVerifier);
 
   await setCodeVerifier(codeVerifier);
 
@@ -15,7 +15,7 @@ export async function startOAuthFlow() {
     redirectUri: env.redirectUri,
     codeChallenge,
     externalId: crypto.randomUUID(),
-    _experimentalParams: { flexpa_search_mode: 'true' },
+    flow: { type: 'search' },
   });
 
   return authUrl;

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -4,7 +4,9 @@ import FlexpaClient from '@flexpa/node-sdk';
 import { env } from './env';
 import { setCodeVerifier } from './session';
 
-export async function startOAuthFlow() {
+export type ConsentFlow = 'search' | 'ial2';
+
+export async function startOAuthFlow(flow: ConsentFlow = 'search') {
   const codeVerifier = await FlexpaClient.generateCodeVerifier();
   const codeChallenge = await FlexpaClient.generateCodeChallenge(codeVerifier);
 
@@ -15,7 +17,7 @@ export async function startOAuthFlow() {
     redirectUri: env.redirectUri,
     codeChallenge,
     externalId: crypto.randomUUID(),
-    flow: { type: 'search' },
+    flow: flow === 'ial2' ? { type: 'ial2' } : { type: 'search' },
   });
 
   return authUrl;

--- a/src/lib/sanitize-narrative-html.ts
+++ b/src/lib/sanitize-narrative-html.ts
@@ -1,0 +1,124 @@
+// Minimal allowlist-based sanitizer for FHIR/C-CDA narrative HTML. Browser-only
+// (relies on DOMParser). Strips scripts, event handlers, and unsafe URLs so the
+// narrative can be rendered with dangerouslySetInnerHTML.
+
+const STRIP_CONTENT_TAGS = new Set([
+  'script',
+  'style',
+  'iframe',
+  'object',
+  'embed',
+  'link',
+  'meta',
+]);
+const ALLOWED_TAGS = new Set([
+  'a',
+  'b',
+  'br',
+  'caption',
+  'div',
+  'em',
+  'i',
+  'li',
+  'ol',
+  'p',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'th',
+  'thead',
+  'tr',
+  'u',
+  'ul',
+]);
+const GLOBAL_ALLOWED_ATTRIBUTES = new Set(['colspan', 'rowspan']);
+const TAG_ALLOWED_ATTRIBUTES: Partial<Record<string, Set<string>>> = {
+  a: new Set(['href', 'title', 'target', 'rel']),
+  th: new Set(['scope']),
+};
+const SAFE_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+function isSafeUrl(value: string) {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.startsWith('//')) {
+    return false;
+  }
+
+  if (trimmedValue.startsWith('#') || trimmedValue.startsWith('/')) {
+    return true;
+  }
+
+  try {
+    const url = new URL(trimmedValue, 'https://example.com');
+    return SAFE_URL_PROTOCOLS.has(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeElement(element: Element) {
+  const tagName = element.tagName.toLowerCase();
+
+  if (STRIP_CONTENT_TAGS.has(tagName)) {
+    element.remove();
+    return;
+  }
+
+  if (!ALLOWED_TAGS.has(tagName)) {
+    element.replaceWith(...Array.from(element.childNodes));
+    return;
+  }
+
+  for (const attribute of Array.from(element.attributes)) {
+    const attributeName = attribute.name.toLowerCase();
+    const allowedAttributes = TAG_ALLOWED_ATTRIBUTES[tagName];
+    const isAllowedAttribute =
+      GLOBAL_ALLOWED_ATTRIBUTES.has(attributeName) ||
+      Boolean(allowedAttributes?.has(attributeName));
+
+    if (!isAllowedAttribute || attributeName.startsWith('on')) {
+      element.removeAttribute(attribute.name);
+      continue;
+    }
+
+    if (
+      (attributeName === 'href' || attributeName === 'src') &&
+      !isSafeUrl(attribute.value)
+    ) {
+      element.removeAttribute(attribute.name);
+    }
+  }
+
+  if (tagName === 'a') {
+    const target = element.getAttribute('target');
+    if (target === '_blank') {
+      element.setAttribute('rel', 'noopener noreferrer');
+    } else {
+      element.removeAttribute('target');
+      element.removeAttribute('rel');
+    }
+  }
+
+  for (const child of Array.from(element.children)) {
+    sanitizeElement(child);
+  }
+}
+
+export function sanitizeNarrativeHtml(html: string): string {
+  const parsed = new DOMParser().parseFromString(
+    `<body>${html}</body>`,
+    'text/html',
+  );
+  const body = parsed.body;
+
+  for (const child of Array.from(body.children)) {
+    sanitizeElement(child);
+  }
+
+  return body.innerHTML;
+}

--- a/src/lib/sanitize-narrative-html.ts
+++ b/src/lib/sanitize-narrative-html.ts
@@ -1,17 +1,10 @@
-// Minimal allowlist-based sanitizer for FHIR/C-CDA narrative HTML. Browser-only
-// (relies on DOMParser). Strips scripts, event handlers, and unsafe URLs so the
-// narrative can be rendered with dangerouslySetInnerHTML.
+// Allowlist-based sanitizer for FHIR/C-CDA narrative HTML, delegated to
+// DOMPurify so the narrative can be rendered with dangerouslySetInnerHTML.
+// Browser-only (DOMPurify relies on the DOM).
 
-const STRIP_CONTENT_TAGS = new Set([
-  'script',
-  'style',
-  'iframe',
-  'object',
-  'embed',
-  'link',
-  'meta',
-]);
-const ALLOWED_TAGS = new Set([
+import DOMPurify from 'dompurify';
+
+const ALLOWED_TAGS = [
   'a',
   'b',
   'br',
@@ -34,91 +27,24 @@ const ALLOWED_TAGS = new Set([
   'tr',
   'u',
   'ul',
-]);
-const GLOBAL_ALLOWED_ATTRIBUTES = new Set(['colspan', 'rowspan']);
-const TAG_ALLOWED_ATTRIBUTES: Partial<Record<string, Set<string>>> = {
-  a: new Set(['href', 'title', 'target', 'rel']),
-  th: new Set(['scope']),
-};
-const SAFE_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+];
+const ALLOWED_ATTR = [
+  'href',
+  'title',
+  'target',
+  'rel',
+  'colspan',
+  'rowspan',
+  'scope',
+];
 
-function isSafeUrl(value: string) {
-  const trimmedValue = value.trim();
-
-  if (trimmedValue.startsWith('//')) {
-    return false;
+// target=_blank links need rel=noopener noreferrer; DOMPurify won't add it for us.
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+    node.setAttribute('rel', 'noopener noreferrer');
   }
-
-  if (trimmedValue.startsWith('#') || trimmedValue.startsWith('/')) {
-    return true;
-  }
-
-  try {
-    const url = new URL(trimmedValue, 'https://example.com');
-    return SAFE_URL_PROTOCOLS.has(url.protocol);
-  } catch {
-    return false;
-  }
-}
-
-function sanitizeElement(element: Element) {
-  const tagName = element.tagName.toLowerCase();
-
-  if (STRIP_CONTENT_TAGS.has(tagName)) {
-    element.remove();
-    return;
-  }
-
-  if (!ALLOWED_TAGS.has(tagName)) {
-    element.replaceWith(...Array.from(element.childNodes));
-    return;
-  }
-
-  for (const attribute of Array.from(element.attributes)) {
-    const attributeName = attribute.name.toLowerCase();
-    const allowedAttributes = TAG_ALLOWED_ATTRIBUTES[tagName];
-    const isAllowedAttribute =
-      GLOBAL_ALLOWED_ATTRIBUTES.has(attributeName) ||
-      Boolean(allowedAttributes?.has(attributeName));
-
-    if (!isAllowedAttribute || attributeName.startsWith('on')) {
-      element.removeAttribute(attribute.name);
-      continue;
-    }
-
-    if (
-      (attributeName === 'href' || attributeName === 'src') &&
-      !isSafeUrl(attribute.value)
-    ) {
-      element.removeAttribute(attribute.name);
-    }
-  }
-
-  if (tagName === 'a') {
-    const target = element.getAttribute('target');
-    if (target === '_blank') {
-      element.setAttribute('rel', 'noopener noreferrer');
-    } else {
-      element.removeAttribute('target');
-      element.removeAttribute('rel');
-    }
-  }
-
-  for (const child of Array.from(element.children)) {
-    sanitizeElement(child);
-  }
-}
+});
 
 export function sanitizeNarrativeHtml(html: string): string {
-  const parsed = new DOMParser().parseFromString(
-    `<body>${html}</body>`,
-    'text/html',
-  );
-  const body = parsed.body;
-
-  for (const child of Array.from(body.children)) {
-    sanitizeElement(child);
-  }
-
-  return body.innerHTML;
+  return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR });
 }

--- a/src/lib/sanitize-narrative-html.ts
+++ b/src/lib/sanitize-narrative-html.ts
@@ -39,6 +39,9 @@ const ALLOWED_ATTR = [
 ];
 
 // target=_blank links need rel=noopener noreferrer; DOMPurify won't add it for us.
+// Registered once on the default singleton at module load. This is the only
+// DOMPurify usage in the app, so the global hook is fine; if another caller is
+// added with different needs, move to a dedicated instance via createDOMPurify.
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
     node.setAttribute('rel', 'noopener noreferrer');


### PR DESCRIPTION
## Why
The quickstart should demonstrate Flexpa's IAL2/TEFCA consent flow end to end, including rendering the C-CDA clinical documents that come back from CommonWell, and should clearly explain which networks each consent option reaches.

## What
- Bump `@flexpa/node-sdk` to `^2.0.0` and switch the OAuth start to the new `flow: { type: 'ial2' | 'search' }` param (replacing `_experimentalParams.flexpa_search_mode`); PKCE helpers are now awaited. Adds a `ConsentFlow` type.
- Home page consent cards now name their networks: Search covers health insurer (CMS-9115) and medical record system (ONC (g)(10)) networks; Identity verification (IAL2) uses the TEFCA nationwide network via the CommonWell and Kno2 QHINs.
- New DocumentReference attachment viewer (`document-attachment.tsx`): structured C-CDA section browser, decoded-text view, and download. "Open link" only shows when there's no inline base64 `data` (raw upstream Binary URLs require a Bearer token and 401 on plain browser requests; per the docs the URL path is a signed `binary.flexpa.com` URL).
- New C-CDA helpers (`ccda.ts`): base64 normalize/decode and parse C-CDA XML into navigable narrative sections. New `sanitize-narrative-html.ts` (tag/attr allowlist, strips scripts and unsafe URLs) and `narrative-html.tsx` to render it.
- `$everything` explorer (`everything.tsx`): DocumentReference gets a Document/Resource tab pair, and the per-type example browser now lists every instance via a dropdown (removed the previous 3-instance cap).
- New `empty-results.tsx` empty state wired into the coverage, eob, patient, and everything responses.
- Dashboard: FHIR API Explorer card now appears before Parsed Records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-option OAuth consent flow with "Search" and "Identity verification (IAL2)"
  * Document attachments viewer with text, C-CDA rendering, download/open actions
  * Narrative HTML renderer for sanitized clinical HTML
  * C-CDA parsing and base64 decoding utilities

* **UX Improvements**
  * Empty-state UI reused across requests (Patient, Coverage, EOB, Everything)
  * Resource explorer: dropdown to pick examples; dashboard cards reordered
  * Clearer error messaging when OAuth initialization fails

* **Chores**
  * Updated SDK and added DOMPurify dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->