### PR TITLE
fix(quickstart): narrative sanitizer crashed dashboard SSR on load

### DIFF
--- a/src/lib/sanitize-narrative-html.ts
+++ b/src/lib/sanitize-narrative-html.ts
@@ -1,6 +1,4 @@
-// Allowlist-based sanitizer for FHIR/C-CDA narrative HTML, delegated to
-// DOMPurify so the narrative can be rendered with dangerouslySetInnerHTML.
-// Browser-only (DOMPurify relies on the DOM).
+// Allowlist sanitizer for FHIR/C-CDA narrative HTML, via DOMPurify. Browser-only.
 
 import DOMPurify from 'dompurify';
 
@@ -38,16 +36,21 @@ const ALLOWED_ATTR = [
   'scope',
 ];
 
-// target=_blank links need rel=noopener noreferrer; DOMPurify won't add it for us.
-// Registered once on the default singleton at module load. This is the only
-// DOMPurify usage in the app, so the global hook is fine; if another caller is
-// added with different needs, move to a dedicated instance via createDOMPurify.
-DOMPurify.addHook('afterSanitizeAttributes', (node) => {
-  if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
-    node.setAttribute('rel', 'noopener noreferrer');
-  }
-});
+// Add rel=noopener to target=_blank links. Registered lazily, not at module
+// load: DOMPurify isn't DOM-bound during SSR, where this module still evaluates.
+let hookRegistered = false;
+
+function ensureHook(): void {
+  if (hookRegistered) return;
+  hookRegistered = true;
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A' && node.getAttribute('target') === '_blank') {
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+}
 
 export function sanitizeNarrativeHtml(html: string): string {
+  ensureHook();
   return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR });
 }


### PR DESCRIPTION
## Problem

Opening the dashboard document viewer threw a runtime error and crashed SSR:

```
DOMPurify.addHook is not a function
  at src/lib/sanitize-narrative-html.ts
```

## Root cause

#173 replaced the hand-rolled narrative sanitizer with DOMPurify and registered a `rel=noopener` hook at module load. DOMPurify's default export is only DOM-bound in the browser; during SSR it's the unbound factory with no `addHook`. The client component that imports this module is still evaluated on the server, so the top-level `addHook` call threw before any render.

This slipped past `next build`: the dashboard route is server-rendered on demand, not statically prerendered, so the module was never evaluated at build time.

## Fix

Register the hook lazily on the first `sanitizeNarrativeHtml` call instead of at module load. That path only runs in the browser (the caller already guards on `window`), so the hook is registered once, client-side, and module evaluation stays DOM-free.

Follow-up to #173.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HTML sanitization logic to improve performance during server-side rendering while maintaining the same security and functionality for sanitizing narrative content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->